### PR TITLE
Update Framework & Push Footer down to bottom

### DIFF
--- a/_layouts/blank.html
+++ b/_layouts/blank.html
@@ -75,7 +75,7 @@
           <div class="col l3 s12">
             <h5 class="white-text">Project links</h5>
             <ul>
-              <li><a class="white-text" href="https://github.com/cSploit/android">Github Project Page</a></li>
+              <li><u><a class="white-text" href="https://github.com/cSploit/android">Github Project Page</a></u></li>
             </ul>
           </div>
           <div class="col l3 s12">

--- a/_layouts/blank.html
+++ b/_layouts/blank.html
@@ -59,7 +59,9 @@
       </div>
     </nav>
     <br/>
+    <main>
 {{ content }}
+    </main>
     <br />
     <footer class="page-footer light-blue darken-4">
       <div class="container">

--- a/_layouts/blank.html
+++ b/_layouts/blank.html
@@ -27,8 +27,8 @@
     <script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
     <script src="{{ "init.js" | prepend: site.baseurl }}"></script>
     
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.1/css/materialize.min.css">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.1/js/materialize.min.js"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.5/css/materialize.min.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.5/js/materialize.min.js"></script>
     
     {% if site.isso_domain and page.id %}<script data-isso="http://{{ site.isso_domain }}" src="//{{ site.isso_domain }}/js/embed.min.js"></script>{% endif %}
   </head>


### PR DESCRIPTION
Updated Framework to 0.97.5 and adding main-tag to push down footer to the bottom.

**BUT:**
Can you add a custom "style.css" file and include it? I don't know how that works here :smile: 
Example: http://dev.dominiktv.net/csploit/ -> Right-click -> View source and in order like line 9 - 12 *(include style.css at last)*

In the style.css - file, please add

```
body {
    display: flex;
    min-height: 100vh;
    flex-direction: column;
  }
  main {
    flex: 1 0 auto;
  }
```